### PR TITLE
Shrunk font size of axis labels on funding graphs

### DIFF
--- a/imds-master.css
+++ b/imds-master.css
@@ -191,6 +191,8 @@ a.leaflet-popup-close-button:hover {background: transparent; color: black;}
 .chart {min-height: 300px;}
 #graph-wetlands-ibi.chart {height: 200px; min-height: 200px;}
 .ct-label {font-size: 1.2rem; color: rgba(0,0,0, .7);}
+#graph-funding-peryear .ct-label, #graph-funding-cumul .ct-label {font-size: 1rem;} /* Shrink font size of axis labels slightly on funding graphs, so that the currency formatting fits */
+/*.ct-label.ct-horizontal.ct-end {position: relative; display: block; white-space: nowrap; transform: rotate(-90deg); transform-origin: 100% 0;}*/ /* For rotating x-axis labels */
 .ct-series-a .ct-point, .ct-series-a .ct-line, .ct-series-a .ct-bar, .ct-series-a .ct-slice-donut {stroke: #329096; stroke: #c55227; stroke: #923411;}
 .graph-meta {float: left; width: 100%; border-bottom: 0px solid #ccc; }
 .graph-meta .list-inline {background: #ddefc8; background: #d0e5fd; margin: -10px -10px 10px; padding: 5px;}


### PR DESCRIPTION
When numbers on y-axis are formatted as "$12,000,000" and exceed 7 digits, they don't fit anymore, so I shrank them.