### PR TITLE
Removed now-defunct "Related Content" & "Edit project" links

### DIFF
--- a/index.html
+++ b/index.html
@@ -536,10 +536,10 @@
         {{#city}}{{city}}, {{/city}} {{#province}}{{province}}{{/province}} {{#postal_code}}{{postal_code}}{{/postal_code}}
         </p> 
 
-      {{#related_content}}<h3>Related content</h3><p> {{{related_content}}}</p>{{/related_content}}
+      <!--{{#related_content}}<h3>Related content</h3><p> {{{related_content}}}</p>{{/related_content}}
 
 
-      <span class="edit-project pull-right"><a href="{{path}}" target="_blank"><i class="fa fa-pencil-square-o"></i> Edit project</a></span>
+      <span class="edit-project pull-right"><a href="{{path}}" target="_blank"><i class="fa fa-pencil-square-o"></i> Edit project</a></span>-->
 
 
 
@@ -577,6 +577,6 @@
 <script src='https://api.mapbox.com/mapbox.js/v3.0.1/mapbox.js'></script>
 <script src="https://unpkg.com/esri-leaflet@2.0.6"></script>
 <!-- <script src='https://api.mapbox.com/mapbox.js/v3.0.1/mapbox.standalone.js'></script>
- --><script type="text/javascript" src="bundle.min.js"></script>    
+ --><script type="text/javascript" src="bundle.js"></script>    
 </body>
 </html>


### PR DESCRIPTION
These links don't work anymore and/or go back to the old Great Lakes Inform site. This can be fixed later either by manually altering the CARTO table (bad b/c very tedious) or setting up a new GeoJSON feed on the new Blue Accounting site.